### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/Phoenix/src/main/java/com/yalantis/phoenix/util/Logger.java
+++ b/Phoenix/src/main/java/com/yalantis/phoenix/util/Logger.java
@@ -13,6 +13,8 @@ public final class Logger {
     private static boolean logEnabled_i = false;
     private static boolean logEnabled_e = false;
 
+    private Logger () {}
+
     public static void d() {
         if (logEnabled_d) {
             android.util.Log.v(TAG, getLocation());

--- a/Phoenix/src/main/java/com/yalantis/phoenix/util/Utils.java
+++ b/Phoenix/src/main/java/com/yalantis/phoenix/util/Utils.java
@@ -4,6 +4,8 @@ import android.content.Context;
 
 public class Utils {
 
+    private Utils() {}
+
     public static int convertDpToPixel(Context context, int dp) {
         float density = context.getResources().getDisplayMetrics().density;
         return Math.round((float) dp * density);

--- a/app/src/main/java/com/tellh/android_pulltorefreshlibrary_collection/WaterDropListView/Utils.java
+++ b/app/src/main/java/com/tellh/android_pulltorefreshlibrary_collection/WaterDropListView/Utils.java
@@ -12,6 +12,8 @@ import android.view.ViewGroup;
  */
 public class Utils {
 
+    private Utils() {}
+
     /**
      * Map a value within a given range to another range.
      * @param value the value to map

--- a/app/src/main/java/com/tellh/android_pulltorefreshlibrary_collection/util/Logger.java
+++ b/app/src/main/java/com/tellh/android_pulltorefreshlibrary_collection/util/Logger.java
@@ -13,6 +13,8 @@ public final class Logger {
     private static boolean logEnabled_i = false;
     private static boolean logEnabled_e = false;
 
+    private Logger() {}
+
     public static void d() {
         if (logEnabled_d) {
             android.util.Log.v(TAG, getLocation());

--- a/jellyrefresh/src/main/java/uk/co/imallan/jellyrefresh/MathUtils.java
+++ b/jellyrefresh/src/main/java/uk/co/imallan/jellyrefresh/MathUtils.java
@@ -6,6 +6,8 @@ package uk.co.imallan.jellyrefresh;
  */
 class MathUtils {
 
+    private MathUtils() {}
+
     public static int constrains(int input, int a, int b) {
         int result = input;
         final int min = Math.min(a, b);

--- a/swipetorefreshlayoutgoogle/src/main/java/com/tellh/swipetorefreshlayoutgoogle/util/Logger.java
+++ b/swipetorefreshlayoutgoogle/src/main/java/com/tellh/swipetorefreshlayoutgoogle/util/Logger.java
@@ -13,6 +13,8 @@ public final class Logger {
     private static boolean logEnabled_i = false;
     private static boolean logEnabled_e = false;
 
+    private Logger() {}
+
     public static void d() {
         if (logEnabled_d) {
             android.util.Log.v(TAG, getLocation());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat
