### PR TITLE
squid:UselessParenthesesCheck - Useless parentheses around expression…

### DIFF
--- a/Phoenix/src/main/java/com/yalantis/phoenix/PullToRefreshView.java
+++ b/Phoenix/src/main/java/com/yalantis/phoenix/PullToRefreshView.java
@@ -242,7 +242,7 @@ public class PullToRefreshView extends ViewGroup {
                 float tensionSlingshotPercent = Math.max(0,
                         Math.min(extraOS, slingshotDist * 2) / slingshotDist);
                 float tensionPercent = (float) ((tensionSlingshotPercent / 4) - Math.pow(
-                        (tensionSlingshotPercent / 4), 2)) * 2f;
+                        tensionSlingshotPercent / 4, 2)) * 2f;
                 float extraMove = (slingshotDist) * tensionPercent / 2;
                 //未松手前，target下拉的总高度 int
 //                int targetY = (int) scrollTop; //可以替代下面这句代码，效果一样
@@ -352,7 +352,7 @@ public class PullToRefreshView extends ViewGroup {
         public void applyTransformation(float interpolatedTime, Transformation t) {
             int targetTop;
             int endTarget = mTotalDragDistance;
-            targetTop = (mFrom + (int) ((endTarget - mFrom) * interpolatedTime));
+            targetTop = mFrom + (int) ((endTarget - mFrom) * interpolatedTime);
             int offset = targetTop - mTarget.getTop();
 
             mCurrentDragPercent = mFromDragPercent - (mFromDragPercent - 1.0f) * interpolatedTime;

--- a/Phoenix/src/main/java/com/yalantis/phoenix/refresh_view/SunRefreshView.java
+++ b/Phoenix/src/main/java/com/yalantis/phoenix/refresh_view/SunRefreshView.java
@@ -86,16 +86,16 @@ public class SunRefreshView extends BaseRefreshView implements Animatable {
 
         mScreenWidth = viewWidth;
         mSkyHeight = (int) (SKY_RATIO * mScreenWidth);
-        mSkyTopOffset = (mSkyHeight * 0.38f);
+        mSkyTopOffset = mSkyHeight * 0.38f;
         mSkyMoveOffset = Utils.convertDpToPixel(getContext(), 15);
 
         mTownHeight = (int) (TOWN_RATIO * mScreenWidth);
-        mTownInitialTopOffset = (mParent.getTotalDragDistance() - mTownHeight * TOWN_INITIAL_SCALE);
-        mTownFinalTopOffset = (mParent.getTotalDragDistance() - mTownHeight * TOWN_FINAL_SCALE);
+        mTownInitialTopOffset = mParent.getTotalDragDistance() - mTownHeight * TOWN_INITIAL_SCALE;
+        mTownFinalTopOffset = mParent.getTotalDragDistance() - mTownHeight * TOWN_FINAL_SCALE;
         mTownMoveOffset = Utils.convertDpToPixel(getContext(), 10);
 
         mSunLeftOffset = 0.3f * (float) mScreenWidth;
-        mSunTopOffset = (mParent.getTotalDragDistance() * 0.1f);
+        mSunTopOffset = mParent.getTotalDragDistance() * 0.1f;
 
         mTop = -mParent.getTotalDragDistance();
 

--- a/app/src/main/java/com/tellh/android_pulltorefreshlibrary_collection/PullToRefreshLayoutTellH/PullToRefreshLayout.java
+++ b/app/src/main/java/com/tellh/android_pulltorefreshlibrary_collection/PullToRefreshLayoutTellH/PullToRefreshLayout.java
@@ -270,7 +270,7 @@ public class PullToRefreshLayout extends ViewGroup {
                     float tensionSlingshotPercent = Math.max(0,
                             Math.min(extraOS, slingshotDist * 2) / slingshotDist);
                     float tensionPercent = (float) ((tensionSlingshotPercent / 4) - Math.pow(
-                            (tensionSlingshotPercent / 4), 2)) * 2f;
+                            tensionSlingshotPercent / 4, 2)) * 2f;
                     float extraMove = (slingshotDist) * tensionPercent / 2;
                     targetY = (int) ((slingshotDist * boundedDragPercent) + extraMove);
                 } else {
@@ -367,7 +367,7 @@ public class PullToRefreshLayout extends ViewGroup {
         public void applyTransformation(float interpolatedTime, Transformation t) {
             int targetTop;
             int endTarget = mTotalDragDistance;
-            targetTop = (mFrom + (int) ((endTarget - mFrom) * interpolatedTime));
+            targetTop = mFrom + (int) ((endTarget - mFrom) * interpolatedTime);
             int offset = targetTop - mTarget.getTop();
 
             mCurrentDragPercent = mFromDragPercent - (mFromDragPercent - 1.0f) * interpolatedTime;

--- a/app/src/main/java/com/tellh/android_pulltorefreshlibrary_collection/WaterDropListView/WaterDropView.java
+++ b/app/src/main/java/com/tellh/android_pulltorefreshlibrary_collection/WaterDropListView/WaterDropView.java
@@ -158,14 +158,14 @@ public class WaterDropView extends View {
 
         mPath.lineTo(top_x1, top_y1);
 
-        mPath.quadTo((bottomCircle.getX() - bottomCircle.getRadius()),
+        mPath.quadTo(bottomCircle.getX() - bottomCircle.getRadius(),
                 (bottomCircle.getY() + topCircle.getY()) / 2,
 
                 bottom_x1,
                 bottom_y1);
         mPath.lineTo(bottom_x2, bottom_y2);
 
-        mPath.quadTo((bottomCircle.getX() + bottomCircle.getRadius()),
+        mPath.quadTo(bottomCircle.getX() + bottomCircle.getRadius(),
                 (bottomCircle.getY() + top_y2) / 2,
                 top_x2,
                 top_y2);

--- a/circlerefreshlayout/src/main/java/com/tuesda/walker/circlerefresh/AnimationView.java
+++ b/circlerefreshlayout/src/main/java/com/tuesda/walker/circlerefresh/AnimationView.java
@@ -354,7 +354,7 @@ public class AnimationView extends View {
             int curCentY = (int) (startCentY + (PULL_DELTA / 2 + mRadius * 2) * fraction);
             canvas.drawCircle(mWidth / 2, curCentY, mRadius, mBallPaint);
             if (curCentY >= PULL_HEIGHT - mRadius * 2) {
-                drawTail(canvas, curCentY, PULL_HEIGHT, (1 - fraction));
+                drawTail(canvas, curCentY, PULL_HEIGHT, 1 - fraction);
             }
         }
 

--- a/swipetorefreshlayoutgoogle/src/main/java/com/tellh/swipetorefreshlayoutgoogle/CircleImageView.java
+++ b/swipetorefreshlayoutgoogle/src/main/java/com/tellh/swipetorefreshlayoutgoogle/CircleImageView.java
@@ -145,9 +145,9 @@ class CircleImageView extends ImageView {
         public void draw(Canvas canvas, Paint paint) {
             final int viewWidth = CircleImageView.this.getWidth();
             final int viewHeight = CircleImageView.this.getHeight();
-            canvas.drawCircle(viewWidth / 2, viewHeight / 2, (mCircleDiameter / 2 + mShadowRadius),
+            canvas.drawCircle(viewWidth / 2, viewHeight / 2, mCircleDiameter / 2 + mShadowRadius,
                     mShadowPaint);
-            canvas.drawCircle(viewWidth / 2, viewHeight / 2, (mCircleDiameter / 2), paint);
+            canvas.drawCircle(viewWidth / 2, viewHeight / 2, mCircleDiameter / 2, paint);
         }
     }
 }

--- a/swipetorefreshlayoutgoogle/src/main/java/com/tellh/swipetorefreshlayoutgoogle/MaterialProgressDrawable.java
+++ b/swipetorefreshlayoutgoogle/src/main/java/com/tellh/swipetorefreshlayoutgoogle/MaterialProgressDrawable.java
@@ -321,7 +321,7 @@ class MaterialProgressDrawable extends Drawable implements Animatable {
         return (int)((startA + (int)(fraction * (endA - startA))) << 24) |
                 (int)((startR + (int)(fraction * (endR - startR))) << 16) |
                 (int)((startG + (int)(fraction * (endG - startG))) << 8) |
-                (int)((startB + (int)(fraction * (endB - startB))));
+                (int)(startB + (int)(fraction * (endB - startB)));
     }
 
     /**
@@ -567,8 +567,8 @@ class MaterialProgressDrawable extends Drawable implements Animatable {
                 // been fixed as of API 21.
                 mArrow.moveTo(0, 0);
                 mArrow.lineTo(mArrowWidth * mArrowScale, 0);
-                mArrow.lineTo((mArrowWidth * mArrowScale / 2), (mArrowHeight
-                        * mArrowScale));
+                mArrow.lineTo(mArrowWidth * mArrowScale / 2), (mArrowHeight
+                        * mArrowScale);
                 mArrow.offset(x - inset, y);
                 mArrow.close();
                 // draw a triangle

--- a/swipetorefreshlayoutgoogle/src/main/java/com/tellh/swipetorefreshlayoutgoogle/SwipeRefreshTestLayout.java
+++ b/swipetorefreshlayoutgoogle/src/main/java/com/tellh/swipetorefreshlayoutgoogle/SwipeRefreshTestLayout.java
@@ -656,8 +656,8 @@ public class SwipeRefreshTestLayout extends ViewGroup implements NestedScrolling
         //将mCircleView放在mTarget的平面位置上面居中，初始化时是完全隐藏在屏幕外的
         int circleWidth = mCircleView.getMeasuredWidth();
         int circleHeight = mCircleView.getMeasuredHeight();
-        mCircleView.layout((width / 2 - circleWidth / 2), mCurrentTargetOffsetTop,
-                (width / 2 + circleWidth / 2), mCurrentTargetOffsetTop + circleHeight);
+        mCircleView.layout(width / 2 - circleWidth / 2, mCurrentTargetOffsetTop,
+                width / 2 + circleWidth / 2, mCurrentTargetOffsetTop + circleHeight);
     }
 
     @Override
@@ -830,7 +830,7 @@ public class SwipeRefreshTestLayout extends ViewGroup implements NestedScrolling
         float tensionSlingshotPercent = Math.max(0, Math.min(extraOS, slingshotDist * 2)
                 / slingshotDist);
         float tensionPercent = (float) ((tensionSlingshotPercent / 4) - Math.pow(
-                (tensionSlingshotPercent / 4), 2)) * 2f;
+                tensionSlingshotPercent / 4, 2)) * 2f;
         float extraMove = (slingshotDist) * tensionPercent * 2;
 
         //计算spinner将要（target）被移动到的位置对应的Y坐标,当targetY为0时，小圆圈刚好全部露出来
@@ -1041,7 +1041,7 @@ public class SwipeRefreshTestLayout extends ViewGroup implements NestedScrolling
             } else {
                 endTarget = (int) mSpinnerFinalOffset;
             }
-            targetTop = (mFrom + (int) ((endTarget - mFrom) * interpolatedTime));
+            targetTop = mFrom + (int) ((endTarget - mFrom) * interpolatedTime);
             int offset = targetTop - mCircleView.getTop();
             setTargetOffsetTopAndBottom(offset, false /* requires update */);
             mProgress.setArrowScale(1 - interpolatedTime);
@@ -1050,7 +1050,7 @@ public class SwipeRefreshTestLayout extends ViewGroup implements NestedScrolling
 
     private void moveToStart(float interpolatedTime) {
         int targetTop = 0;
-        targetTop = (mFrom + (int) ((mOriginalOffsetTop - mFrom) * interpolatedTime));
+        targetTop = mFrom + (int) ((mOriginalOffsetTop - mFrom) * interpolatedTime);
         int offset = targetTop - mCircleView.getTop();
         setTargetOffsetTopAndBottom(offset, false /* requires update */);
     }
@@ -1073,7 +1073,7 @@ public class SwipeRefreshTestLayout extends ViewGroup implements NestedScrolling
         mScaleDownToStartAnimation = new Animation() {
             @Override
             public void applyTransformation(float interpolatedTime, Transformation t) {
-                float targetScale = (mStartingScale + (-mStartingScale  * interpolatedTime));
+                float targetScale = mStartingScale + (-mStartingScale  * interpolatedTime);
                 setAnimationProgress(targetScale);
                 moveToStart(interpolatedTime);
             }

--- a/taurus_flyplane/src/main/java/com/yalantis/taurus/PullToRefreshView.java
+++ b/taurus_flyplane/src/main/java/com/yalantis/taurus/PullToRefreshView.java
@@ -175,7 +175,7 @@ public class PullToRefreshView extends ViewGroup {
                 float tensionSlingshotPercent = Math.max(0,
                         Math.min(extraOS, slingshotDist * 2) / slingshotDist);
                 float tensionPercent = (float) ((tensionSlingshotPercent / 4) - Math.pow(
-                        (tensionSlingshotPercent / 4), 2)) * 2f;
+                        tensionSlingshotPercent / 4, 2)) * 2f;
                 float extraMove = (slingshotDist) * tensionPercent / 2;
                 int targetY = (int) ((slingshotDist * boundedDragPercent) + extraMove);
 
@@ -269,7 +269,7 @@ public class PullToRefreshView extends ViewGroup {
         public void applyTransformation(float interpolatedTime, @NonNull Transformation t) {
             int targetTop;
             int endTarget = mTotalDragDistance;
-            targetTop = (mFrom + (int) ((endTarget - mFrom) * interpolatedTime));
+            targetTop = mFrom + (int) ((endTarget - mFrom) * interpolatedTime);
             int offset = targetTop - mTarget.getTop();
 
             mCurrentDragPercent = mFromDragPercent - (mFromDragPercent - 1.0f) * interpolatedTime;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:UselessParenthesesCheck

Please let me know if you have any questions.

M-Ezzat
