### PR TITLE
squid:SwitchLastCaseIsDefaultCheck - switch statements should end wit…

### DIFF
--- a/Phoenix/src/main/java/com/yalantis/phoenix/PullToRefreshView.java
+++ b/Phoenix/src/main/java/com/yalantis/phoenix/PullToRefreshView.java
@@ -205,6 +205,8 @@ public class PullToRefreshView extends ViewGroup {
             case MotionEventCompat.ACTION_POINTER_UP:
                 onSecondaryPointerUp(ev);
                 break;
+            default:
+                break;
         }
 
         //如果是正在被下拉拖动，拦截，不往下传递；反之，你懂的
@@ -289,6 +291,8 @@ public class PullToRefreshView extends ViewGroup {
                 }
                 return false;//系列点击事件已经处理完，将处理权交还mTarget
             }
+            default:
+                break;
         }
 
         return true;//该系列点击事件未处理完，消耗此系列事件

--- a/app/src/main/java/com/tellh/android_pulltorefreshlibrary_collection/MainActivity.java
+++ b/app/src/main/java/com/tellh/android_pulltorefreshlibrary_collection/MainActivity.java
@@ -43,6 +43,8 @@ public class MainActivity extends AppCompatActivity {
 //            case R.id.btn_ultra_refresh_layout:
 //                startActivity(new Intent(MainActivity.this, UltraPullToRefreshActivity.class));
 //                break;
+            default:
+                break;
         }
     }
 

--- a/app/src/main/java/com/tellh/android_pulltorefreshlibrary_collection/PullToRefreshLayoutTellH/PullToRefreshLayout.java
+++ b/app/src/main/java/com/tellh/android_pulltorefreshlibrary_collection/PullToRefreshLayoutTellH/PullToRefreshLayout.java
@@ -229,6 +229,8 @@ public class PullToRefreshLayout extends ViewGroup {
             case MotionEventCompat.ACTION_POINTER_UP:
                 onSecondaryPointerUp(ev);
                 break;
+            default:
+                break;
         }
 
         //如果是正在被下拉拖动，拦截该事件，不往下传递；反之，你懂的
@@ -317,6 +319,8 @@ public class PullToRefreshLayout extends ViewGroup {
                 }
                 return false;//系列点击事件已经处理完，将处理权交还mTarget
             }
+            default:
+                break;
         }
 
         return true;//该系列点击事件未处理完，消耗此系列事件

--- a/circlerefreshlayout/src/main/java/com/tuesda/walker/circlerefresh/AnimationView.java
+++ b/circlerefreshlayout/src/main/java/com/tuesda/walker/circlerefresh/AnimationView.java
@@ -145,6 +145,8 @@ public class AnimationView extends View {
                     break;
                 case REL_DRAG:
                     break;
+                default:
+                    break;
             }
 
         }
@@ -184,6 +186,8 @@ public class AnimationView extends View {
                 break;
             case STOP:
                 drawDone(canvas);
+                break;
+            default:
                 break;
 
         }

--- a/circlerefreshlayout/src/main/java/com/tuesda/walker/circlerefresh/CircleRefreshLayout.java
+++ b/circlerefreshlayout/src/main/java/com/tuesda/walker/circlerefresh/CircleRefreshLayout.java
@@ -207,6 +207,8 @@ public class CircleRefreshLayout extends FrameLayout {
                 if (dy > 0 && !canChildScrollUp()) {
                     return true;
                 }
+            default:
+                break;
         }
         return super.onInterceptTouchEvent(ev);
     }

--- a/jellyrefresh/src/main/java/uk/co/imallan/jellyrefresh/PullToRefreshLayout.java
+++ b/jellyrefresh/src/main/java/uk/co/imallan/jellyrefresh/PullToRefreshLayout.java
@@ -217,6 +217,8 @@ class PullToRefreshLayout extends FrameLayout {
                     return true;
                 }
                 break;
+            default:
+                break;
         }
         return super.onInterceptTouchEvent(e);
     }

--- a/swipetorefreshlayoutgoogle/src/main/java/com/tellh/swipetorefreshlayoutgoogle/SwipeRefreshTestLayout.java
+++ b/swipetorefreshlayoutgoogle/src/main/java/com/tellh/swipetorefreshlayoutgoogle/SwipeRefreshTestLayout.java
@@ -785,6 +785,8 @@ public class SwipeRefreshTestLayout extends ViewGroup implements NestedScrolling
                 mIsBeingDragged = false;
                 mActivePointerId = INVALID_POINTER;
                 break;
+            default:
+                break;
         }
 
         //如果正在被拖拽，拦截该系列的点击事件，并调用自己的onTouchEvent()来处理
@@ -997,6 +999,8 @@ public class SwipeRefreshTestLayout extends ViewGroup implements NestedScrolling
             }
             case MotionEvent.ACTION_CANCEL:
                 return false;
+            default:
+                break;
         }
 
         return true;

--- a/taurus_flyplane/src/main/java/com/yalantis/taurus/PullToRefreshView.java
+++ b/taurus_flyplane/src/main/java/com/yalantis/taurus/PullToRefreshView.java
@@ -141,6 +141,8 @@ public class PullToRefreshView extends ViewGroup {
             case MotionEventCompat.ACTION_POINTER_UP:
                 onSecondaryPointerUp(ev);
                 break;
+            default:
+                break;
         }
 
         return mIsBeingDragged;
@@ -208,6 +210,8 @@ public class PullToRefreshView extends ViewGroup {
                 mActivePointerId = INVALID_POINTER;
                 return false;
             }
+            default:
+                break;
         }
 
         return true;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.

M-Ezzat
