### PR TITLE
Cleanup - squid:S1301 - "switch" statements should have at least 3 "c…

### DIFF
--- a/Phoenix/src/main/java/com/yalantis/phoenix/PullToRefreshView.java
+++ b/Phoenix/src/main/java/com/yalantis/phoenix/PullToRefreshView.java
@@ -103,13 +103,12 @@ public class PullToRefreshView extends ViewGroup {
 
     public void setRefreshStyle(int type) {
         setRefreshing(false);
-        switch (type) {
-            case STYLE_SUN:
-                mBaseRefreshView = new SunRefreshView(getContext(), this);
-                break;
-            default:
-                throw new InvalidParameterException("Type does not exist");
+        if (type != STYLE_SUN) {
+            throw new InvalidParameterException("Type does not exist");
+        } else {
+            mBaseRefreshView = new SunRefreshView(getContext(), this);
         }
+        
         mRefreshView.setImageDrawable(mBaseRefreshView);
     }
 

--- a/app/src/main/java/com/tellh/android_pulltorefreshlibrary_collection/PullToRefreshLayoutTellH/PullToRefreshLayout.java
+++ b/app/src/main/java/com/tellh/android_pulltorefreshlibrary_collection/PullToRefreshLayoutTellH/PullToRefreshLayout.java
@@ -100,11 +100,8 @@ public class PullToRefreshLayout extends ViewGroup {
 
     public void setRefreshStyle(int type) {
         setRefreshing(false);
-        switch (type) {
-            case STYLE_SUN:
-                break;
-            default:
-                throw new InvalidParameterException("Type does not exist");
+        if (type != STYLE_SUN) {
+            throw new InvalidParameterException("Type does not exist");
         }
     }
 

--- a/circlerefreshlayout/src/main/java/com/tuesda/walker/circlerefresh/CircleRefreshLayout.java
+++ b/circlerefreshlayout/src/main/java/com/tuesda/walker/circlerefresh/CircleRefreshLayout.java
@@ -194,19 +194,16 @@ public class CircleRefreshLayout extends FrameLayout {
         if (mIsRefreshing) {
             return true;
         }
-        switch (ev.getAction()) {
-            //记下按下的Y坐标
-            case MotionEvent.ACTION_DOWN:
-                mTouchStartY = ev.getY();
-                mTouchCurY = mTouchStartY;
-                break;
-            case MotionEvent.ACTION_MOVE:
-                float curY = ev.getY();
-                float dy = curY - mTouchStartY;
-                //如果是向下滑动并且已经滑动顶部，拦截点击事件
-                if (dy > 0 && !canChildScrollUp()) {
-                    return true;
-                }
+        if (ev.getAction() == MotionEvent.ACTION_DOWN) {
+            mTouchStartY = ev.getY();
+            mTouchCurY = mTouchStartY;
+        } else if (ev.getAction() == MotionEvent.ACTION_MOVE ) {
+            float curY = ev.getY();
+            float dy = curY - mTouchStartY;
+            //如果是向下滑动并且已经滑动顶部，拦截点击事件
+            if (dy > 0 && !canChildScrollUp()) {
+                return true;
+            }
         }
         return super.onInterceptTouchEvent(ev);
     }

--- a/jellyrefresh/src/main/java/uk/co/imallan/jellyrefresh/PullToRefreshLayout.java
+++ b/jellyrefresh/src/main/java/uk/co/imallan/jellyrefresh/PullToRefreshLayout.java
@@ -205,18 +205,15 @@ class PullToRefreshLayout extends FrameLayout {
         if (isRefreshing) {
             return true;
         }
-        switch (e.getAction()) {
-            case MotionEvent.ACTION_DOWN:
-                mTouchStartY = e.getY();
-                mCurrentY = mTouchStartY;
-                break;
-            case MotionEvent.ACTION_MOVE:
-                float currentY = e.getY();
-                float dy = currentY - mTouchStartY;
-                if (dy > 0 && !canChildScrollUp()) {
-                    return true;
-                }
-                break;
+        if (e.getAction() == MotionEvent.ACTION_DOWN) {
+            mTouchStartY = e.getY();
+            mCurrentY = mTouchStartY;
+        } else if (e.getAction() == MotionEvent.ACTION_MOVE) {
+            float currentY = e.getY();
+            float dy = currentY - mTouchStartY;
+            if (dy > 0 && !canChildScrollUp()) {
+                return true;
+            }
         }
         return super.onInterceptTouchEvent(e);
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1301 - "switch" statements should have at least 3 "case" clauses

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1301

Please let me know if you have any questions.

M-Ezzat
